### PR TITLE
fix: 🐛 center Icon vertically by default

### DIFF
--- a/packages/icon/src/create-icon.tsx
+++ b/packages/icon/src/create-icon.tsx
@@ -2,6 +2,7 @@
 import { Children, forwardRef, ReactElement } from "react"
 import { Icon } from "./icon"
 import { IconProps } from "./interface"
+import { iconContainerStyle } from "./style"
 
 interface CreateIconOptions {
   /**
@@ -44,13 +45,21 @@ export function createIcon(options: CreateIconOptions) {
   } = options
   // eslint-disable-next-line react/display-name
   return forwardRef<SVGSVGElement, IconProps>((props, ref) => (
-    <Icon ref={ref} viewBox={viewBox} fill={fill} {...defaultProps} {...props}>
-      <title>{title}</title>
-      {path ? (
-        Children.toArray(path)
-      ) : (
-        <path fill="currentColor" d={pathDefinition} />
-      )}
-    </Icon>
+    <span css={iconContainerStyle}>
+      <Icon
+        ref={ref}
+        viewBox={viewBox}
+        fill={fill}
+        {...defaultProps}
+        {...props}
+      >
+        <title>{title}</title>
+        {path ? (
+          Children.toArray(path)
+        ) : (
+          <path fill="currentColor" d={pathDefinition} />
+        )}
+      </Icon>
+    </span>
   ))
 }

--- a/packages/icon/src/style.ts
+++ b/packages/icon/src/style.ts
@@ -12,3 +12,17 @@ export const rotateKeyframe = keyframes`
 export const rotateAnimation = css`
   animation: 1s linear infinite ${rotateKeyframe};
 `
+
+export const iconContainerStyle = css`
+  display: inline-flex;
+  align-items: center;
+  font-style: normal;
+  line-height: 0;
+  color: inherit;
+  text-align: center;
+  text-rendering: optimizeLegibility;
+  text-transform: none;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  vertical-align: -0.125em;
+`


### PR DESCRIPTION
## 📝 Description

Add a brief description.

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

lol